### PR TITLE
feat: allow for navigating slide deck with keyboard 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+src/main.tsx
+src/App.tsx
+index.html

--- a/examples/App.tsx
+++ b/examples/App.tsx
@@ -3,7 +3,7 @@ import { Slide } from "../src/Slide";
 
 function App() {
   return (
-    <Deck>
+    <Deck startAt={0} horizontal onScroll={console.log}>
       <Slide
         onEnterViewport={() => console.log("enter First!!")}
         onExitViewport={() => console.log("exit first!!")}

--- a/examples/App.tsx
+++ b/examples/App.tsx
@@ -7,7 +7,7 @@ function App() {
       <Slide
         onEnterViewport={() => console.log("enter First!!")}
         onExitViewport={() => console.log("exit first!!")}
-        style={{ backgroundColor: "black" }}
+        style={{ flexBasis: "100%", backgroundColor: "black" }}
       />
       <Slide
         onEnterViewport={() => console.log("enter second!!")}

--- a/examples/main.tsx
+++ b/examples/main.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -31,7 +31,7 @@ export const Deck: React.FC<DeckProps> = ({
 }) => {
   const deckRef = React.useRef<null | HTMLDivElement>(null);
   const slides = React.useRef<HTMLDivElement[]>([]);
-  const currentSlide = React.useRef<number>(startAt);
+  const currentSlide = React.useRef<number>(0);
 
   const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> =
     React.useCallback(
@@ -79,6 +79,7 @@ export const Deck: React.FC<DeckProps> = ({
     slides.current.at(startAt)?.scrollIntoView({
       behavior: "instant",
     });
+    currentSlide.current = startAt;
   }, [startAt]);
 
   React.useEffect(

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -99,7 +99,7 @@ export const Deck: React.FC<DeckProps> = ({
     [horizontal, onScroll]
   );
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     deckRef.current?.focus();
   }, []);
 

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -102,7 +102,8 @@ export const Deck: React.FC<DeckProps> = ({
     <div
       {...rest}
       style={{
-        height: "100vh",
+        height: horizontal ? "auto" : "100vh",
+        width: horizontal ? "100vw" : "auto",
         ...style,
         scrollSnapType: horizontal ? "x mandatory" : "y mandatory",
         overflow: "scroll",

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -65,8 +65,9 @@ export const Deck: React.FC<DeckProps> = ({
     if (!disableScrollbarsFor) return;
 
     disableScrollbarsFor
-      .map(document.querySelectorAll)
-      .flatMap((collection) => [...collection] as HTMLElement[])
+      .flatMap(
+        (query) => [...document.querySelectorAll(query)] as HTMLElement[]
+      )
       .forEach((element) => {
         element.style.overflow = "hidden";
       });

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -88,8 +88,9 @@ export const Deck: React.FC<DeckProps> = ({
   React.useEffect(
     () =>
       scroll(({ x, y }) => {
-        if (horizontal) onScroll?.(x.progress);
-        else onScroll?.(y.progress);
+        const progress = horizontal ? x.progress : y.progress;
+
+        onScroll?.(progress);
       }),
     [horizontal, onScroll]
   );

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -93,13 +93,9 @@ export const Deck: React.FC<DeckProps> = ({
       onKeyUp={onKeyUp}
     >
       {React.Children.map(children, (child, idx) => {
-        if (child?.type !== Slide) {
-          return null;
-        }
+        if (child?.type !== Slide) return null;
 
-        if (idx === 0) {
-          slides.current = [];
-        }
+        if (idx === 0) slides.current = [];
 
         return React.cloneElement(child, {
           ref: (instance: HTMLDivElement | null) => {

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -26,24 +26,31 @@ export const Deck: React.FC<DeckProps> = ({
   const currentSlide = React.useRef<number>(startAt);
 
   const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> =
-    React.useCallback((event) => {
-      if (event.key !== "ArrowDown") return;
+    React.useCallback(
+      (event) => {
+        const VALID_KEY = horizontal ? "ArrowLeft" : "ArrowDown";
 
-      if (
-        currentSlide.current <= 0 ||
-        currentSlide.current >= slides.current.length - 1
-      )
-        return;
+        if (event.key !== VALID_KEY) return;
 
-      const nextSlide = currentSlide.current - 1;
+        if (
+          currentSlide.current <= 0 ||
+          currentSlide.current >= slides.current.length - 1
+        )
+          return;
 
-      slides.current.at(nextSlide)?.scrollIntoView();
-      currentSlide.current = nextSlide;
-    }, []);
+        const nextSlide = currentSlide.current - 1;
+
+        slides.current.at(nextSlide)?.scrollIntoView();
+        currentSlide.current = nextSlide;
+      },
+      [horizontal]
+    );
 
   const onKeyUp: React.KeyboardEventHandler<HTMLDivElement> = React.useCallback(
     (event) => {
-      if (event.key !== "ArrowUp") return;
+      const VALID_KEY = horizontal ? "ArrowRight" : "ArrowUp";
+
+      if (event.key !== VALID_KEY) return;
 
       if (
         currentSlide.current <= 0 ||
@@ -56,7 +63,7 @@ export const Deck: React.FC<DeckProps> = ({
       slides.current.at(nextSlide)?.scrollIntoView();
       currentSlide.current = nextSlide;
     },
-    []
+    [horizontal]
   );
 
   React.useLayoutEffect(() => {

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -81,13 +81,13 @@ export const Deck: React.FC<DeckProps> = ({
       });
   }, [disableScrollbarsFor]);
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     if (isOutOfBounds(startAt, slides.current)) return;
 
     slides.current.at(startAt)?.scrollIntoView();
   }, [startAt]);
 
-  React.useLayoutEffect(
+  React.useEffect(
     () =>
       scroll(({ x, y }) => {
         if (horizontal) {

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -25,6 +25,9 @@ export const Deck: React.FC<DeckProps> = ({
   const slides = React.useRef<HTMLDivElement[]>([]);
   const currentSlide = React.useRef<number>(startAt);
 
+  const isOutOfBounds = (idx: number) =>
+    slides.current.length > 0 && (idx <= 0 || idx >= slides.current.length - 1);
+
   const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> =
     React.useCallback(
       (event) => {
@@ -32,11 +35,7 @@ export const Deck: React.FC<DeckProps> = ({
 
         if (event.key !== VALID_KEY) return;
 
-        if (
-          currentSlide.current <= 0 ||
-          currentSlide.current >= slides.current.length - 1
-        )
-          return;
+        if (isOutOfBounds(currentSlide.current)) return;
 
         const nextSlide = currentSlide.current - 1;
 
@@ -52,11 +51,7 @@ export const Deck: React.FC<DeckProps> = ({
 
       if (event.key !== VALID_KEY) return;
 
-      if (
-        currentSlide.current <= 0 ||
-        currentSlide.current >= slides.current.length - 1
-      )
-        return;
+      if (isOutOfBounds(currentSlide.current)) return;
 
       const nextSlide = currentSlide.current + 1;
 
@@ -78,7 +73,7 @@ export const Deck: React.FC<DeckProps> = ({
   }, [disableScrollbarsFor]);
 
   React.useLayoutEffect(() => {
-    if (startAt <= 0 || startAt >= slides.current.length - 1) return;
+    if (isOutOfBounds(startAt)) return;
 
     slides.current.at(startAt)?.scrollIntoView();
   }, [startAt]);

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -103,8 +103,8 @@ export const Deck: React.FC<DeckProps> = ({
   }, []);
 
   const classNames = [
-    horizontal ? "w-auto h-screen" : "h-auto w-screen",
     horizontal ? "snap-x" : "snap-y",
+    "w-screen h-screen",
     "overflow-scroll",
     "smooth-scroll",
     className ?? "",

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -46,10 +46,8 @@ export const Deck: React.FC<DeckProps> = ({
 
         slides.current.at(nextSlide)?.scrollIntoView();
         currentSlide.current = nextSlide;
-
-        onScroll?.(getProgress(nextSlide, slides.current));
       },
-      [horizontal, onScroll]
+      [horizontal]
     );
 
   const onKeyUp: React.KeyboardEventHandler<HTMLDivElement> = React.useCallback(
@@ -64,10 +62,8 @@ export const Deck: React.FC<DeckProps> = ({
 
       slides.current.at(nextSlide)?.scrollIntoView();
       currentSlide.current = nextSlide;
-
-      onScroll?.(getProgress(nextSlide, slides.current));
     },
-    [horizontal, onScroll]
+    [horizontal]
   );
 
   React.useLayoutEffect(() => {
@@ -140,6 +136,3 @@ type HTMLElementTagName = keyof HTMLElementTagNameMap;
 
 const isOutOfBounds = (idx: number, slides: HTMLDivElement[]) =>
   slides.length > 0 && (idx <= 0 || idx >= slides.length - 1);
-
-const getProgress = (idx: number, slides: HTMLDivElement[]) =>
-  (idx + 1) / slides.length;

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -73,7 +73,7 @@ export const Deck: React.FC<DeckProps> = ({
       });
   }, [disableScrollbarsFor]);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (!isWithinBounds(startAt, slides.current)) return;
 
     slides.current.at(startAt)?.scrollIntoView({

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -28,6 +28,7 @@ export const Deck: React.FC<DeckProps> = ({
   onScroll,
   ...rest
 }) => {
+  const deckRef = React.useRef<null | HTMLDivElement>(null);
   const slides = React.useRef<HTMLDivElement[]>([]);
   const currentSlide = React.useRef<number>(startAt);
 
@@ -98,9 +99,15 @@ export const Deck: React.FC<DeckProps> = ({
     [horizontal, onScroll]
   );
 
+  React.useLayoutEffect(() => {
+    deckRef.current?.focus();
+  }, []);
+
   return (
     <div
       {...rest}
+      ref={deckRef}
+      tabIndex={0}
       style={{
         height: horizontal ? "auto" : "100vh",
         width: horizontal ? "100vw" : "auto",

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -116,7 +116,7 @@ export const Deck: React.FC<DeckProps> = ({
         if (child?.type !== Slide) return null;
 
         // NOTE: While developing, the render function gets called twice
-        // so there are 6 elements in `slides`, relying on the fact that
+        // so there are 2x elements in `slides`, relying on the fact that
         // the elements are rendered in order to reset the array between re-renders
         return React.cloneElement(child, {
           ref: (instance: HTMLDivElement | null) => {

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -86,15 +86,17 @@ export const Deck: React.FC<DeckProps> = ({
     slides.current.at(startAt)?.scrollIntoView();
   }, [startAt]);
 
-  React.useLayoutEffect(() => {
-    scroll(({ x, y }) => {
-      if (horizontal) {
-        onScroll?.(x.progress);
-      } else {
-        onScroll?.(y.progress);
-      }
-    });
-  }, [horizontal, onScroll]);
+  React.useLayoutEffect(
+    () =>
+      scroll(({ x, y }) => {
+        if (horizontal) {
+          onScroll?.(x.progress);
+        } else {
+          onScroll?.(y.progress);
+        }
+      }),
+    [horizontal, onScroll]
+  );
 
   return (
     <div

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -1,10 +1,13 @@
 import React from "react";
+import { Slide, type SlideProps } from "../Slide";
 
 export interface DeckProps
   extends React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   > {
+  startAt?: number;
+  children: React.ReactElement<SlideProps> | React.ReactElement<SlideProps>[];
   horizontal?: boolean;
   disableScrollbarsFor?: false | (HTMLElementTagName | string)[];
 }
@@ -15,8 +18,47 @@ export const Deck: React.FC<DeckProps> = ({
   style,
   horizontal,
   disableScrollbarsFor = DEFAULT_SELECTORS,
+  startAt = 0,
+  children,
   ...rest
 }) => {
+  const slides = React.useRef<HTMLDivElement[]>([]);
+  const currentSlide = React.useRef<number>(startAt);
+
+  const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> =
+    React.useCallback((event) => {
+      if (event.key !== "ArrowDown") return;
+
+      if (
+        currentSlide.current <= 0 ||
+        currentSlide.current >= slides.current.length - 1
+      )
+        return;
+
+      const nextSlide = currentSlide.current - 1;
+
+      slides.current.at(nextSlide)?.scrollIntoView();
+      currentSlide.current = nextSlide;
+    }, []);
+
+  const onKeyUp: React.KeyboardEventHandler<HTMLDivElement> = React.useCallback(
+    (event) => {
+      if (event.key !== "ArrowUp") return;
+
+      if (
+        currentSlide.current <= 0 ||
+        currentSlide.current >= slides.current.length - 1
+      )
+        return;
+
+      const nextSlide = currentSlide.current + 1;
+
+      slides.current.at(nextSlide)?.scrollIntoView();
+      currentSlide.current = nextSlide;
+    },
+    []
+  );
+
   React.useLayoutEffect(() => {
     if (!disableScrollbarsFor) return;
 
@@ -28,6 +70,12 @@ export const Deck: React.FC<DeckProps> = ({
       });
   }, [disableScrollbarsFor]);
 
+  React.useLayoutEffect(() => {
+    if (startAt <= 0 || startAt >= slides.current.length - 1) return;
+
+    slides.current.at(startAt)?.scrollIntoView();
+  }, [startAt]);
+
   return (
     <div
       {...rest}
@@ -38,7 +86,27 @@ export const Deck: React.FC<DeckProps> = ({
         overflow: "scroll",
         scrollBehavior: "smooth",
       }}
-    />
+      onKeyDown={onKeyDown}
+      onKeyUp={onKeyUp}
+    >
+      {React.Children.map(children, (child, idx) => {
+        if (child?.type !== Slide) {
+          return null;
+        }
+
+        if (idx === 0) {
+          slides.current = [];
+        }
+
+        return React.cloneElement(child, {
+          ref: (instance: HTMLDivElement | null) => {
+            if (!instance) return;
+
+            slides.current.push(instance);
+          },
+        });
+      })}
+    </div>
   );
 };
 

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Slide, type SlideProps } from "../Slide";
 import { scroll } from "motion";
+import "./styles.css";
 
 export interface DeckProps
   extends Omit<
@@ -20,12 +21,12 @@ export interface DeckProps
 const DEFAULT_SELECTORS: HTMLElementTagName[] = ["html", "body"];
 
 export const Deck: React.FC<DeckProps> = ({
-  style,
   horizontal,
   disableScrollbarsFor = DEFAULT_SELECTORS,
   startAt = 0,
   children,
   onScroll,
+  className,
   ...rest
 }) => {
   const deckRef = React.useRef<null | HTMLDivElement>(null);
@@ -77,7 +78,8 @@ export const Deck: React.FC<DeckProps> = ({
         (query) => [...document.querySelectorAll(query)] as HTMLElement[]
       )
       .forEach((element) => {
-        element.style.overflow = "hidden";
+        if (!element.classList.contains("overflow-hidden"))
+          element.classList.add("overflow-hidden");
       });
   }, [disableScrollbarsFor]);
 
@@ -90,11 +92,8 @@ export const Deck: React.FC<DeckProps> = ({
   React.useEffect(
     () =>
       scroll(({ x, y }) => {
-        if (horizontal) {
-          onScroll?.(x.progress);
-        } else {
-          onScroll?.(y.progress);
-        }
+        if (horizontal) onScroll?.(x.progress);
+        else onScroll?.(y.progress);
       }),
     [horizontal, onScroll]
   );
@@ -103,19 +102,20 @@ export const Deck: React.FC<DeckProps> = ({
     deckRef.current?.focus();
   }, []);
 
+  const classNames = [
+    horizontal ? "w-auto h-screen" : "h-auto w-screen",
+    horizontal ? "snap-x" : "snap-y",
+    "overflow-scroll",
+    "smooth-scroll",
+    className ?? "",
+  ].filter(Boolean);
+
   return (
     <div
       {...rest}
       ref={deckRef}
       tabIndex={0}
-      style={{
-        height: horizontal ? "auto" : "100vh",
-        width: horizontal ? "100vw" : "auto",
-        ...style,
-        scrollSnapType: horizontal ? "x mandatory" : "y mandatory",
-        overflow: "scroll",
-        scrollBehavior: "smooth",
-      }}
+      className={classNames.join(" ")}
       onKeyDown={onKeyDown}
       onKeyUp={onKeyUp}
     >

--- a/src/Deck/styles.css
+++ b/src/Deck/styles.css
@@ -1,35 +1,27 @@
-h-auto {
-    height: auto;
-}
-
-h-screen {
+.h-screen {
     height: 100vh;
 }
 
-w-auto {
-    height: auto;
-}
-
-w-screen {
+.w-screen {
     width: 100vw;
 }
 
-snap-x {
+.snap-x {
     scroll-snap-type: x mandatory;
 }
 
-snap-y {
+.snap-y {
     scroll-snap-type: y mandatory;
 }
 
-overflow-scroll {
+.overflow-scroll {
     overflow: scroll;
 }
 
-overflow-hidden {
+.overflow-hidden {
     overflow: hidden;
 }
 
-scroll-smooth {
+.scroll-smooth {
     scroll-behavior: smooth;
 }

--- a/src/Deck/styles.css
+++ b/src/Deck/styles.css
@@ -1,0 +1,35 @@
+h-auto {
+    height: auto;
+}
+
+h-screen {
+    height: 100vh;
+}
+
+w-auto {
+    height: auto;
+}
+
+w-screen {
+    width: 100vw;
+}
+
+snap-x {
+    scroll-snap-type: x mandatory;
+}
+
+snap-y {
+    scroll-snap-type: y mandatory;
+}
+
+overflow-scroll {
+    overflow: scroll;
+}
+
+overflow-hidden {
+    overflow: hidden;
+}
+
+scroll-smooth {
+    scroll-behavior: smooth;
+}

--- a/src/Deck/styles.css
+++ b/src/Deck/styles.css
@@ -1,9 +1,21 @@
+body {
+    margin: 0rem 0rem 0rem 0rem;
+}
+
 .h-screen {
     height: 100vh;
 }
 
 .w-screen {
     width: 100vw;
+}
+
+.h-full {
+    height: 100%;
+}
+
+.w-full {
+    width: 100%;
 }
 
 .snap-x {
@@ -24,4 +36,8 @@
 
 .scroll-smooth {
     scroll-behavior: smooth;
+}
+
+.flex {
+    display: flex;
 }

--- a/src/Slide/index.tsx
+++ b/src/Slide/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { type InViewOptions, type ViewChangeHandler, inView } from "motion";
+import "./styles.css";
 
 export interface SlideProps
   extends React.DetailedHTMLProps<
@@ -23,7 +24,7 @@ export const Slide = React.forwardRef<SlideHandles, SlideProps>(
       onEnterViewport,
       onExitViewport,
       options = DEFAULT_OPTIONS,
-      style,
+      className,
       ...rest
     },
     ref
@@ -48,17 +49,13 @@ export const Slide = React.forwardRef<SlideHandles, SlideProps>(
       return inView(slideRef.current, onStart, options);
     }, [onEnterViewport, onExitViewport, options]);
 
-    return (
-      <div
-        {...rest}
-        ref={slideRef}
-        style={{
-          height: "100vh",
-          width: "100vw",
-          scrollSnapAlign: "start",
-          ...style,
-        }}
-      />
-    );
+    const classNames = [
+      "h-screen",
+      "w-screen",
+      "snap-start",
+      className ?? "",
+    ].filter(Boolean);
+
+    return <div {...rest} ref={slideRef} className={classNames.join(" ")} />;
   }
 );

--- a/src/Slide/index.tsx
+++ b/src/Slide/index.tsx
@@ -32,8 +32,8 @@ export const Slide = React.forwardRef<SlideHandles, SlideProps>(
     const slideRef = React.useRef<null | HTMLDivElement>(null);
 
     const createHandles = (): SlideHandles => ({
-      scrollIntoView: () =>
-        (slideRef.current as HTMLDivElement).scrollIntoView(),
+      scrollIntoView: (arg?: boolean | ScrollIntoViewOptions) =>
+        (slideRef.current as HTMLDivElement).scrollIntoView(arg),
     });
 
     React.useImperativeHandle(ref, createHandles, []);

--- a/src/Slide/index.tsx
+++ b/src/Slide/index.tsx
@@ -36,7 +36,7 @@ export const Slide = React.forwardRef<SlideHandles, SlideProps>(
 
     React.useImperativeHandle(ref, createHandles, []);
 
-    React.useLayoutEffect(() => {
+    React.useEffect(() => {
       if (!slideRef.current) return;
 
       const onStart: ViewChangeHandler = (entry) => {

--- a/src/Slide/index.tsx
+++ b/src/Slide/index.tsx
@@ -32,7 +32,8 @@ export const Slide = React.forwardRef<SlideHandles, SlideProps>(
     const slideRef = React.useRef<null | HTMLDivElement>(null);
 
     const createHandles = (): SlideHandles => ({
-      scrollIntoView: (slideRef.current as HTMLDivElement).scrollIntoView,
+      scrollIntoView: () =>
+        (slideRef.current as HTMLDivElement).scrollIntoView(),
     });
 
     React.useImperativeHandle(ref, createHandles, []);

--- a/src/Slide/index.tsx
+++ b/src/Slide/index.tsx
@@ -11,9 +11,7 @@ export interface SlideProps
   options?: InViewOptions;
 }
 
-export interface SlideHandles {
-  scrollIntoView: () => void;
-}
+export type SlideHandles = Pick<HTMLDivElement, "scrollIntoView">;
 
 const DEFAULT_OPTIONS: InViewOptions = {
   amount: 0.5,
@@ -33,7 +31,7 @@ export const Slide = React.forwardRef<SlideHandles, SlideProps>(
     const slideRef = React.useRef<null | HTMLDivElement>(null);
 
     const createHandles = (): SlideHandles => ({
-      scrollIntoView: () => slideRef.current?.scrollIntoView(),
+      scrollIntoView: (slideRef.current as HTMLDivElement).scrollIntoView,
     });
 
     React.useImperativeHandle(ref, createHandles, []);
@@ -41,7 +39,7 @@ export const Slide = React.forwardRef<SlideHandles, SlideProps>(
     React.useLayoutEffect(() => {
       if (!slideRef.current) return;
 
-      const onStart = (entry: IntersectionObserverEntry) => {
+      const onStart: ViewChangeHandler = (entry) => {
         onEnterViewport?.(entry);
 
         return onExitViewport;

--- a/src/Slide/styles.css
+++ b/src/Slide/styles.css
@@ -1,11 +1,11 @@
-h-screen {
+.h-screen {
     height: 100vh;
 }
 
-w-screen {
+.w-screen {
     height: 100vw;
 }
 
-snap-start {
+.snap-start {
     scroll-snap-align: start;
 }

--- a/src/Slide/styles.css
+++ b/src/Slide/styles.css
@@ -1,0 +1,11 @@
+h-screen {
+    height: 100vh;
+}
+
+w-screen {
+    height: 100vw;
+}
+
+snap-start {
+    scroll-snap-align: start;
+}


### PR DESCRIPTION
And starting at some specified slide

- For horizontal, having trouble getting the css right to have `w-screen h-screen` arranged horizontally so that the deck overflows in the x direction. flex does not seem to cut it
- alternative is to show only one slide at a time and use motion to control the transitions but the preference is to rely on overflow